### PR TITLE
Command to log logical trace sizes over time

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,23 +209,30 @@ where you should now see something like the following:
 $ tdiag --source-peers 2 differential arrangements
 
 Listening for 2 Timely connections on 127.0.0.1:51317
-Listening for 2 Differential connections on 127.0.0.1:51318
+Listening for 2 Differential connections on 127.0.0.1:51319
+Will report every 1000ms
 Trace sources connected
-(((0, 18), (649, "Arrange ([0, 4, 6])")), 1s, 1)
-(((0, 20), (5944, "Arrange ([0, 4, 7])")), 1s, 1)
-(((0, 28), (3763, "Arrange ([0, 4, 10])")), 1s, 1)
-(((0, 30), (651, "Reduce ([0, 4, 11])")), 1s, 1)
-(((1, 18), (676, "Arrange ([0, 4, 6])")), 1s, 1)
-(((1, 20), (6006, "Arrange ([0, 4, 7])")), 1s, 1)
-(((1, 28), (3889, "Arrange ([0, 4, 10])")), 1s, 1)
-(((1, 30), (678, "Reduce ([0, 4, 11])")), 1s, 1)
-(((0, 18), (649, "Arrange ([0, 4, 6])")), 2s, -1)
+
+ms	Worker	Op. Id	Name	# of tuples
+1000	0	18	Arrange ([0, 4, 6])	654
+1000	0	20	Arrange ([0, 4, 7])	5944
+1000	0	28	Arrange ([0, 4, 10])	3790
+1000	0	30	Reduce ([0, 4, 11])	654
+1000	1	18	Arrange ([0, 4, 6])	679
+1000	1	20	Arrange ([0, 4, 7])	6006
+1000	1	28	Arrange ([0, 4, 10])	3913
+1000	1	30	Reduce ([0, 4, 11])	678
+2000	0	18	Arrange ([0, 4, 6])	654
+2000	0	18	Arrange ([0, 4, 6])	950
+2000	0	20	Arrange ([0, 4, 7])	5944
+2000	0	20	Arrange ([0, 4, 7])	6937
+2000	0	28	Arrange ([0, 4, 10])	3790
 ```
 
-An output tuple such as `(((1, 20), (6006, "Arrange ([0, 4, 7])")),
-1s, 1)` should be read as "Arrangement 20 ('Arrange ([0, 4, 7])') at
-worker 1 contains 6006 tuples". Updated sizes will be reported every
-second.
+Each row of output specifies the time of the measurement, worker and
+operator ids, the name of the arrangement and the number of tuples it
+maintains. Updated sizes will be reported every second by default,
+this can be controlled via the `output-interval` parameter.
 
 ## The `tdiag-connect` library
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ similar to the following:
 You can use your mouse or touchpad to move the graph around, and to
 zoom in and out.
 
-### `profile` - Visualize the Source Dataflow
+### `profile` - Profile the Source Dataflow
 
 The `profile` subcommand reports aggregate runtime for each scope/operator.
 
@@ -143,6 +143,89 @@ scopes (denoted by `[scope]`) include the time of all contained operators.
 	Probe	(id=6, addr=[0, 4]):	7.86e-6 s
 	Input	(id=1, addr=[0, 1]):	3.408e-6 s
 ```
+
+## Diagnosing Differential Dataflows
+
+The `differential` subcommand groups diagnostic tools that are only
+relevant to timely dataflows that make use of [differential
+dataflow](https://github.com/TimelyDataflow/differential-dataflow). To
+enable Differential logging in your own computation, add the following
+snippet to your code:
+
+``` rust
+if let Ok(addr) = ::std::env::var("DIFFERENTIAL_LOG_ADDR") {
+    if let Ok(stream) = ::std::net::TcpStream::connect(&addr) {
+        differential_dataflow::logging::enable(worker, stream);
+        info!("enabled DIFFERENTIAL logging to {}", addr);
+    } else {
+        panic!("Could not connect to differential log address: {:?}", addr);
+    }
+}
+```
+
+With this snippet included in your executable, you can use any of the
+following tools to analyse differential-specific aspects of your
+computation.
+
+### `differential arrangements` - Track the Size of Differential Arrangements
+
+Stateful differential dataflow operators often maintain indexed input
+traces called `arrangements`. You will want to understand how these
+traces grow (through the accumulation of new inputs) and shrink
+(through compaction) in size, as your computation executes.
+
+```shell
+tdiag --source-peers differential arrangements
+```
+
+You should be presented with a notice informing you that `tdiag` is
+waiting for as many connections as specified via `--source-peers` (two
+in this case).
+
+In a separate shell, start your source computation. In this case, we
+will analyse the [Differential BFS
+example](https://github.com/TimelyDataflow/differential-dataflow/blob/master/examples/bfs.rs). From
+inside the differential dataflow repository, run:
+
+``` shell
+export TIMELY_WORKER_LOG_ADDR="127.0.0.1:51317"
+export DIFFERENTIAL_LOG_ADDR="127.0.0.1:51318"
+
+cargo run --example bfs 1000 10000 100 20 false -w 2
+```
+
+When analysing differential dataflows (in contrast to pure timely
+computations), both `TIMELY_WORKER_LOG_ADDR` and
+`DIFFERENTIAL_LOG_ADDR` must be set for the source workers to connect
+to our diagnostic computation. The `-w` parameter specifies the number
+of workers we want to run the PageRank example with. Whatever we
+specify here therefore has to match the `--source-peers` parameter we
+used when starting `tdiag`.
+
+Once the computation is running, head back to the diagnostic shell,
+where you should now see something like the following:
+
+```shell
+$ tdiag --source-peers 2 differential arrangements
+
+Listening for 2 Timely connections on 127.0.0.1:51317
+Listening for 2 Differential connections on 127.0.0.1:51318
+Trace sources connected
+(((0, 18), (649, "Arrange ([0, 4, 6])")), 1s, 1)
+(((0, 20), (5944, "Arrange ([0, 4, 7])")), 1s, 1)
+(((0, 28), (3763, "Arrange ([0, 4, 10])")), 1s, 1)
+(((0, 30), (651, "Reduce ([0, 4, 11])")), 1s, 1)
+(((1, 18), (676, "Arrange ([0, 4, 6])")), 1s, 1)
+(((1, 20), (6006, "Arrange ([0, 4, 7])")), 1s, 1)
+(((1, 28), (3889, "Arrange ([0, 4, 10])")), 1s, 1)
+(((1, 30), (678, "Reduce ([0, 4, 11])")), 1s, 1)
+(((0, 18), (649, "Arrange ([0, 4, 6])")), 2s, -1)
+```
+
+An output tuple such as `(((1, 20), (6006, "Arrange ([0, 4, 7])")),
+1s, 1)` should be read as "Arrangement 20 ('Arrange ([0, 4, 7])') at
+worker 1 contains 6006 tuples". Updated sizes will be reported every
+second.
 
 ## The `tdiag-connect` library
 

--- a/tdiag/Cargo.toml
+++ b/tdiag/Cargo.toml
@@ -13,4 +13,5 @@ edition = "2018"
 timely = "^0.10"
 differential-dataflow = "^0.10"
 clap = "^2.33"
-tdiag-connect = "^0.2"
+# tdiag-connect = "^0.2"
+tdiag-connect = { path = "../connect" }

--- a/tdiag/src/commands/arrangements.rs
+++ b/tdiag/src/commands/arrangements.rs
@@ -61,7 +61,7 @@ pub fn listen(
                 .filter(|(_, worker, _)| *worker == 0)
                 .flat_map(|(t, _, x)| {
                     if let Operates(event) = x {
-                        Some(((event.id, event.name), t, 1 as isize))
+                        Some(((event.id, format!("{} ({:?})", event.name, event.addr)), t, 1 as isize))
                     } else {
                         None
                     }

--- a/tdiag/src/commands/arrangements.rs
+++ b/tdiag/src/commands/arrangements.rs
@@ -1,0 +1,74 @@
+//! "arrangements" subcommand: cli tool to extract logical arrangement
+//! sizes over time.
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use crate::DiagError;
+
+use timely::dataflow::operators::{Filter, Map};
+
+use differential_dataflow::collection::AsCollection;
+use differential_dataflow::operators::reduce::Count;
+use differential_dataflow::logging::DifferentialEvent;
+use DifferentialEvent::{Merge, Batch};
+
+use tdiag_connect::receive::ReplayWithShutdown;
+
+/// @TODO
+pub fn listen(
+    timely_configuration: timely::Configuration,
+    sockets: Vec<Option<std::net::TcpStream>>,) -> Result<(), crate::DiagError> {
+
+    let sockets = Arc::new(Mutex::new(sockets));
+
+    let is_running = Arc::new(std::sync::atomic::AtomicBool::new(true));
+    let is_running_w = is_running.clone();
+
+    timely::execute(timely_configuration, move |worker| {
+        let sockets = sockets.clone();
+
+        // create replayer from disjoint partition of source worker identifiers.
+        let replayer = tdiag_connect::receive::make_readers::<Duration, (Duration, timely::logging::WorkerIdentifier, DifferentialEvent)>(
+            tdiag_connect::receive::ReplaySource::Tcp(sockets), worker.index(), worker.peers())
+            .expect("failed to open tcp readers");
+            
+        worker.dataflow::<Duration, _, _>(|scope| {
+
+            let window_size = Duration::from_secs(1);
+            
+            replayer.replay_with_shutdown_into(scope, is_running_w.clone())
+                .filter(|(_, worker, _)| *worker == 0)
+                .flat_map(|(t, _, x)| match x {
+                    Batch(x) => Some((x.operator, t, x.length as isize)),
+                    Merge(x) => {
+                        match x.complete {
+                            None => None,
+                            Some(complete_size) => {
+                                let size_diff = (complete_size as isize) - (x.length1 + x.length2) as isize;
+                                
+                                Some((x.operator, t, size_diff as isize))
+                            }
+                        }
+                    }
+                    _ => None,
+                })
+                .as_collection()
+                .count()
+                .delay(move |t| {
+                    let w_secs = window_size.as_secs();
+
+                    let secs_coarsened = if w_secs == 0 {
+                        t.as_secs()
+                    } else {
+                        (t.as_secs() / w_secs + 1) * w_secs
+                    };
+
+                    Duration::new(secs_coarsened, 0)
+                })
+                .inspect(|x| println!("{:?}", x));
+        })
+    }).map_err(|x| DiagError(format!("error in the timely computation: {}", x)))?;
+
+    Ok(())
+}

--- a/tdiag/src/commands/arrangements.rs
+++ b/tdiag/src/commands/arrangements.rs
@@ -7,54 +7,90 @@ use std::time::Duration;
 use crate::DiagError;
 
 use timely::dataflow::operators::{Filter, Map};
+use timely::logging::{TimelyEvent, WorkerIdentifier};
+use TimelyEvent::Operates;
 
 use differential_dataflow::collection::AsCollection;
-use differential_dataflow::operators::reduce::Count;
 use differential_dataflow::logging::DifferentialEvent;
-use DifferentialEvent::{Merge, Batch};
+use differential_dataflow::operators::{Count, Join};
+use DifferentialEvent::{Batch, Merge};
 
 use tdiag_connect::receive::ReplayWithShutdown;
 
 /// @TODO
 pub fn listen(
     timely_configuration: timely::Configuration,
-    sockets: Vec<Option<std::net::TcpStream>>,) -> Result<(), crate::DiagError> {
-
-    let sockets = Arc::new(Mutex::new(sockets));
+    timely_sockets: Vec<Option<std::net::TcpStream>>,
+    differential_sockets: Vec<Option<std::net::TcpStream>>,
+) -> Result<(), crate::DiagError> {
+    let timely_sockets = Arc::new(Mutex::new(timely_sockets));
+    let differential_sockets = Arc::new(Mutex::new(differential_sockets));
 
     let is_running = Arc::new(std::sync::atomic::AtomicBool::new(true));
     let is_running_w = is_running.clone();
 
     timely::execute(timely_configuration, move |worker| {
-        let sockets = sockets.clone();
+        let timely_sockets = timely_sockets.clone();
+        let differential_sockets = differential_sockets.clone();
 
-        // create replayer from disjoint partition of source worker identifiers.
-        let replayer = tdiag_connect::receive::make_readers::<Duration, (Duration, timely::logging::WorkerIdentifier, DifferentialEvent)>(
-            tdiag_connect::receive::ReplaySource::Tcp(sockets), worker.index(), worker.peers())
-            .expect("failed to open tcp readers");
-            
+        let timely_replayer = tdiag_connect::receive::make_readers::<
+            Duration,
+            (Duration, WorkerIdentifier, TimelyEvent),
+        >(
+            tdiag_connect::receive::ReplaySource::Tcp(timely_sockets),
+            worker.index(),
+            worker.peers(),
+        )
+        .expect("failed to open timely tcp readers");
+
+        let differential_replayer = tdiag_connect::receive::make_readers::<
+            Duration,
+            (Duration, WorkerIdentifier, DifferentialEvent),
+        >(
+            tdiag_connect::receive::ReplaySource::Tcp(differential_sockets),
+            worker.index(),
+            worker.peers(),
+        )
+        .expect("failed to open differential tcp readers");
+
         worker.dataflow::<Duration, _, _>(|scope| {
-
             let window_size = Duration::from_secs(1);
-            
-            replayer.replay_with_shutdown_into(scope, is_running_w.clone())
+
+            let operates = timely_replayer
+                .replay_with_shutdown_into(scope, is_running_w.clone())
+                .filter(|(_, worker, _)| *worker == 0)
+                .flat_map(|(t, _, x)| {
+                    if let Operates(event) = x {
+                        Some(((event.id, event.name), t, 1 as isize))
+                    } else {
+                        None
+                    }
+                })
+                .as_collection();
+
+            differential_replayer
+                .replay_with_shutdown_into(scope, is_running_w.clone())
                 .filter(|(_, worker, _)| *worker == 0)
                 .flat_map(|(t, _, x)| match x {
                     Batch(x) => Some((x.operator, t, x.length as isize)),
-                    Merge(x) => {
-                        match x.complete {
-                            None => None,
-                            Some(complete_size) => {
-                                let size_diff = (complete_size as isize) - (x.length1 + x.length2) as isize;
-                                
-                                Some((x.operator, t, size_diff as isize))
-                            }
+                    Merge(x) => match x.complete {
+                        None => None,
+                        Some(complete_size) => {
+                            let size_diff =
+                                (complete_size as isize) - (x.length1 + x.length2) as isize;
+
+                            Some((x.operator, t, size_diff as isize))
                         }
-                    }
+                    },
                     _ => None,
                 })
                 .as_collection()
                 .count()
+                .inner
+                // We do not bother with retractions here, because the
+                // user is only interested in the current count.
+                .filter(|(_, _, count)| count >= &0)
+                .as_collection()
                 .delay(move |t| {
                     let w_secs = window_size.as_secs();
 
@@ -66,9 +102,11 @@ pub fn listen(
 
                     Duration::new(secs_coarsened, 0)
                 })
+                .join(&operates)
                 .inspect(|x| println!("{:?}", x));
         })
-    }).map_err(|x| DiagError(format!("error in the timely computation: {}", x)))?;
+    })
+    .map_err(|x| DiagError(format!("error in the timely computation: {}", x)))?;
 
     Ok(())
 }

--- a/tdiag/src/commands/arrangements.rs
+++ b/tdiag/src/commands/arrangements.rs
@@ -6,14 +6,15 @@ use std::time::Duration;
 
 use crate::DiagError;
 
+use timely::dataflow::operators::generic::operator::Operator;
 use timely::dataflow::operators::{Filter, Map};
 use timely::logging::{TimelyEvent, WorkerIdentifier};
 use TimelyEvent::Operates;
 
 use differential_dataflow::collection::AsCollection;
 use differential_dataflow::logging::DifferentialEvent;
-use differential_dataflow::operators::{Count, Join};
-use DifferentialEvent::{Batch, Merge};
+use differential_dataflow::operators::{Consolidate, Count, Join};
+use DifferentialEvent::{Batch, Merge, MergeShortfall};
 
 use tdiag_connect::receive::ReplayWithShutdown;
 
@@ -58,31 +59,92 @@ pub fn listen(
 
             let operates = timely_replayer
                 .replay_with_shutdown_into(scope, is_running_w.clone())
-                .filter(|(_, worker, _)| *worker == 0)
-                .flat_map(|(t, _, x)| {
+                .flat_map(|(t, worker, x)| {
                     if let Operates(event) = x {
-                        Some(((event.id, format!("{} ({:?})", event.name, event.addr)), t, 1 as isize))
+                        Some((
+                            (
+                                (worker, event.id),
+                                format!("{} ({:?})", event.name, event.addr),
+                            ),
+                            t,
+                            1 as isize,
+                        ))
                     } else {
                         None
                     }
                 })
                 .as_collection();
 
-            differential_replayer
-                .replay_with_shutdown_into(scope, is_running_w.clone())
-                .filter(|(_, worker, _)| *worker == 0)
-                .flat_map(|(t, _, x)| match x {
-                    Batch(x) => Some((x.operator, t, x.length as isize)),
+            let events =
+                differential_replayer.replay_with_shutdown_into(scope, is_running_w.clone());
+
+            // Track time spent merging.
+            events
+                .flat_map(|(t, w, event)| {
+                    if let Merge(event) = event {
+                        Some((t, w, event))
+                    } else {
+                        None
+                    }
+                })
+                .unary(
+                    timely::dataflow::channels::pact::Pipeline,
+                    "MergeTimes",
+                    |_, _| {
+                        let mut map = std::collections::HashMap::new();
+                        let mut vec = Vec::new();
+
+                        move |input, output| {
+                            input.for_each(|time, data| {
+                                data.swap(&mut vec);
+                                let mut session = output.session(&time);
+
+                                for (ts, worker, event) in vec.drain(..) {
+                                    let key = (worker, event.operator);
+
+                                    match event.complete {
+                                        None => {
+                                            assert!(!map.contains_key(&key));
+                                            map.insert(key, ts);
+                                        }
+                                        Some(_) => {
+                                            assert!(map.contains_key(&key));
+                                            let end = map.remove(&key).unwrap();
+                                            let ts_clip =
+                                                std::time::Duration::from_secs(ts.as_secs() + 1);
+                                            let elapsed = ts - end;
+                                            let elapsed_ns = (elapsed.as_secs() as isize)
+                                                * 1_000_000_000
+                                                + (elapsed.subsec_nanos() as isize);
+                                            session.give((key.1, ts_clip, elapsed_ns));
+                                        }
+                                    }
+                                }
+                            });
+                        }
+                    },
+                )
+                .as_collection()
+                .consolidate()
+                .inspect(|x| println!("time {:?}", x));
+
+            // Track sizes.
+            events
+                .flat_map(|(t, worker, x)| match x {
+                    Batch(x) => Some(((worker, x.operator), t, x.length as isize)),
                     Merge(x) => match x.complete {
                         None => None,
                         Some(complete_size) => {
                             let size_diff =
                                 (complete_size as isize) - (x.length1 + x.length2) as isize;
 
-                            Some((x.operator, t, size_diff as isize))
+                            Some(((worker, x.operator), t, size_diff as isize))
                         }
                     },
-                    _ => None,
+                    MergeShortfall(x) => {
+                        eprintln!("MergeShortfall {:?}", x);
+                        None
+                    }
                 })
                 .as_collection()
                 .count()

--- a/tdiag/src/commands/arrangements.rs
+++ b/tdiag/src/commands/arrangements.rs
@@ -28,6 +28,7 @@ pub fn listen(
     timely_configuration: timely::Configuration,
     timely_sockets: Vec<Option<std::net::TcpStream>>,
     differential_sockets: Vec<Option<std::net::TcpStream>>,
+    output_interval_ms: u64, 
 ) -> Result<(), crate::DiagError> {
     let timely_sockets = Arc::new(Mutex::new(timely_sockets));
     let differential_sockets = Arc::new(Mutex::new(differential_sockets));
@@ -57,11 +58,11 @@ pub fn listen(
             worker.index(),
             worker.peers(),
         )
-        .expect("failed to open differential tcp readers");
+            .expect("failed to open differential tcp readers");
+
+        let window_size = Duration::from_millis(output_interval_ms);
 
         worker.dataflow::<Duration, _, _>(|scope| {
-            let window_size = Duration::from_secs(1);
-
             let operates = timely_replayer
                 .replay_with_shutdown_into(scope, is_running_w.clone())
                 .flat_map(|(t, worker, x)| {

--- a/tdiag/src/commands/arrangements.rs
+++ b/tdiag/src/commands/arrangements.rs
@@ -84,58 +84,6 @@ pub fn listen(
             let events =
                 differential_replayer.replay_with_shutdown_into(scope, is_running_w.clone());
 
-            // @TODO Think about where to put this.
-            //
-            // // Track time spent merging.
-            // events
-            //     .flat_map(|(t, w, event)| {
-            //         if let Merge(event) = event {
-            //             Some((t, w, event))
-            //         } else {
-            //             None
-            //         }
-            //     })
-            //     .unary(
-            //         timely::dataflow::channels::pact::Pipeline,
-            //         "MergeTimes",
-            //         |_, _| {
-            //             let mut map = std::collections::HashMap::new();
-            //             let mut vec = Vec::new();
-
-            //             move |input, output| {
-            //                 input.for_each(|time, data| {
-            //                     data.swap(&mut vec);
-            //                     let mut session = output.session(&time);
-
-            //                     for (ts, worker, event) in vec.drain(..) {
-            //                         let key = (worker, event.operator);
-
-            //                         match event.complete {
-            //                             None => {
-            //                                 assert!(!map.contains_key(&key));
-            //                                 map.insert(key, ts);
-            //                             }
-            //                             Some(_) => {
-            //                                 assert!(map.contains_key(&key));
-            //                                 let end = map.remove(&key).unwrap();
-            //                                 let ts_clip =
-            //                                     std::time::Duration::from_secs(ts.as_secs() + 1);
-            //                                 let elapsed = ts - end;
-            //                                 let elapsed_ns = (elapsed.as_secs() as isize)
-            //                                     * 1_000_000_000
-            //                                     + (elapsed.subsec_nanos() as isize);
-            //                                 session.give((key.1, ts_clip, elapsed_ns));
-            //                             }
-            //                         }
-            //                     }
-            //                 });
-            //             }
-            //         },
-            //     )
-            //     .as_collection()
-            //     .consolidate()
-            //     .inspect(|x| println!("time {:?}", x));
-
             // Track sizes.
             events
                 .flat_map(|(t, worker, x)| match x {

--- a/tdiag/src/commands/arrangements.rs
+++ b/tdiag/src/commands/arrangements.rs
@@ -18,7 +18,13 @@ use DifferentialEvent::{Batch, Merge, MergeShortfall};
 
 use tdiag_connect::receive::ReplayWithShutdown;
 
-/// @TODO
+/// Prints the number of tuples maintained in each arrangement.
+///
+/// 1. Listens to incoming connections from a differential-dataflow
+/// program with timely and differential logging enabled;
+/// 2. runs a differential-dataflow program to track batching and
+/// compaction events and derive number of tuples for each trace;
+/// 3. prints the current size alongside arrangement names;
 pub fn listen(
     timely_configuration: timely::Configuration,
     timely_sockets: Vec<Option<std::net::TcpStream>>,
@@ -78,6 +84,8 @@ pub fn listen(
             let events =
                 differential_replayer.replay_with_shutdown_into(scope, is_running_w.clone());
 
+            // @TODO Think about where to put this.
+            //
             // // Track time spent merging.
             // events
             //     .flat_map(|(t, w, event)| {

--- a/tdiag/src/commands/arrangements.rs
+++ b/tdiag/src/commands/arrangements.rs
@@ -6,14 +6,13 @@ use std::time::Duration;
 
 use crate::DiagError;
 
-use timely::dataflow::operators::generic::operator::Operator;
 use timely::dataflow::operators::{Filter, Map};
 use timely::logging::{TimelyEvent, WorkerIdentifier};
 use TimelyEvent::Operates;
 
 use differential_dataflow::collection::AsCollection;
 use differential_dataflow::logging::DifferentialEvent;
-use differential_dataflow::operators::{Consolidate, Count, Join, Threshold};
+use differential_dataflow::operators::{Count, Join};
 use DifferentialEvent::{Batch, Merge, MergeShortfall};
 
 use tdiag_connect::receive::ReplayWithShutdown;

--- a/tdiag/src/commands/arrangements.rs
+++ b/tdiag/src/commands/arrangements.rs
@@ -84,6 +84,9 @@ pub fn listen(
             let events =
                 differential_replayer.replay_with_shutdown_into(scope, is_running_w.clone());
 
+            // Print output header.
+            println!("ms\tWorker\tOp. Id\tName\t# of tuples");
+
             // Track sizes.
             events
                 .flat_map(|(t, worker, x)| match x {
@@ -121,7 +124,9 @@ pub fn listen(
                 })
                 .count()
                 .join(&operates)
-                .inspect(|x| println!("{:?}", x));
+                .inspect(|(((worker, operator), (count, name)), t, _diff)| {
+                    println!("{}\t{}\t{}\t{}\t{}", t.as_millis(), worker, operator, name, count);
+                });
         })
     })
     .map_err(|x| DiagError(format!("error in the timely computation: {}", x)))?;

--- a/tdiag/src/commands/mod.rs
+++ b/tdiag/src/commands/mod.rs
@@ -6,3 +6,4 @@
 
 pub mod graph;
 pub mod profile;
+pub mod arrangements;

--- a/tdiag/src/main.rs
+++ b/tdiag/src/main.rs
@@ -27,12 +27,6 @@ You can customize the interface and port for the receiver (this program) with --
              .help("Port to listen on; defaults to 51317")
              .default_value("51317")
              .required(true))
-        .arg(clap::Arg::with_name("differential-port")
-             .long("differential-port")
-             .value_name("PORT")
-             .help("Port to listen on for Differential log streams; defaults to 51318")
-             .default_value("51318")
-             .required(true))
         .arg(clap::Arg::with_name("source_peers")
              .short("s")
              .long("source-peers")
@@ -61,6 +55,13 @@ You can customize the interface and port for the receiver (this program) with --
         .subcommand(
             clap::SubCommand::with_name("differential")
                 .about("Tools for profiling Timely computations that make use of differential dataflow.")
+                .arg(clap::Arg::with_name("port")
+                     .short("p")
+                     .long("port")
+                     .value_name("PORT")
+                     .help("Port to listen on for Differential log streams; defaults to 51318")
+                     .default_value("51318")
+                     .required(true))
                 .subcommand(
                     clap::SubCommand::with_name("arrangements")
                         .about("Track the logical size of arrangements over the course of a computation")
@@ -79,7 +80,7 @@ if let Ok(addr) = ::std::env::var(\"DIFFERENTIAL_LOG_ADDR\") {
 ```
 
 Then start your computation with the DIFFERENTIAL_LOG_ADDR environment
-variable pointing to the differential-port (51318 by default).
+variable pointing to tdiag's differential port (51318 by default).
 ")
                 )
         )

--- a/tdiag/src/main.rs
+++ b/tdiag/src/main.rs
@@ -48,8 +48,13 @@ You can customize the interface and port for the receiver (this program) with --
                 .help("The output path for the generated html file (don't forget the .html extension)")
                 .required(true))
         )
-        .subcommand(clap::SubCommand::with_name("profile")
-            .about("Print total time spent running each operator")
+        .subcommand(
+            clap::SubCommand::with_name("profile")
+                .about("Print total time spent running each operator")
+        )
+        .subcommand(
+            clap::SubCommand::with_name("arrangements")
+                .about("Track the logical size of arrangements over the course of a computation")                    
         )
         .get_matches();
 
@@ -79,13 +84,19 @@ You can customize the interface and port for the receiver (this program) with --
             let sockets = tdiag_connect::receive::open_sockets(ip_addr, port, source_peers)?;
             println!("Trace sources connected");
             crate::commands::graph::listen_and_render(timely_configuration, sockets, output_path)
-        },
+        }
         ("profile", Some(_profile_args)) => {
             println!("Listening for {} connections on {}:{}", source_peers, ip_addr, port);
             let sockets = tdiag_connect::receive::open_sockets(ip_addr, port, source_peers)?;
             println!("Trace sources connected");
             crate::commands::profile::listen_and_profile(timely_configuration, sockets)
-        },
+        }
+        ("arrangements", Some(_args)) => {
+            println!("Listening for {} connections on {}:{}", source_peers, ip_addr, port);
+            let sockets = tdiag_connect::receive::open_sockets(ip_addr, port, source_peers)?;
+            println!("Trace sources connected");
+            crate::commands::arrangements::listen(timely_configuration, sockets)
+        }
         _                           => panic!("Invalid subcommand"),
     }
 }

--- a/tdiag/src/main.rs
+++ b/tdiag/src/main.rs
@@ -92,12 +92,30 @@ You can customize the interface and port for the receiver (this program) with --
             crate::commands::profile::listen_and_profile(timely_configuration, sockets)
         }
         ("arrangements", Some(_args)) => {
-            println!("Listening for {} connections on {}:{}", source_peers, ip_addr, port);
-            let sockets = tdiag_connect::receive::open_sockets(ip_addr, port, source_peers)?;
+            println!(
+                "Listening for {} Timely connections on {}:{}",
+                source_peers, ip_addr, port
+            );
+            let timely_sockets =
+                tdiag_connect::receive::open_sockets(ip_addr.clone(), port, source_peers)?;
+
+            println!(
+                "Listening for {} Differential connections on {}:{}",
+                source_peers,
+                ip_addr,
+                port + 1
+            );
+            let differential_sockets =
+                tdiag_connect::receive::open_sockets(ip_addr.clone(), port + 1, source_peers)?;
+
             println!("Trace sources connected");
-            crate::commands::arrangements::listen(timely_configuration, sockets)
+            crate::commands::arrangements::listen(
+                timely_configuration,
+                timely_sockets,
+                differential_sockets,
+            )
         }
-        _                           => panic!("Invalid subcommand"),
+        _ => panic!("Invalid subcommand"),
     }
 }
 


### PR DESCRIPTION
Goal of this is to track the number of arranged tuples across all arrangements in the computation, as the computation runs. Right now the only thing is doing is ingesting `Batch` and `Merge` events into a Differential collection `(arrangement_id, t, +-tuples)` and reporting accumulated counts every second.

Remaining TODOs.

- [x] join with `Operates` to extract arrangement names
- [x] make output interval configurable 
- [x] make differential logging port configurable

This is not as plug-n-play, because it requires augmenting a Differential computation with the following snippet:

``` rust
if let Ok(addr) = ::std::env::var("DIFFERENTIAL_LOG_ADDR") {
    info!("enabled DIFFERENTIAL logging to {}", addr);

    if let Ok(stream) = ::std::net::TcpStream::connect(&addr) {
        use differential_dataflow::logging::DifferentialEvent;

        let writer = ::timely::dataflow::operators::capture::EventWriter::new(stream);
        let mut logger = ::timely::logging::BatchLogger::new(writer);

        worker.log_register()
           .insert::<DifferentialEvent,_>("differential/arrange", move |time, data| logger.publish_batch(time, data));
    } else {
        panic!("Could not connect to differential log address: {:?}", addr);
    }
}
```