### PR TITLE
bump timely & differential versions to 0.10

### DIFF
--- a/connect/Cargo.toml
+++ b/connect/Cargo.toml
@@ -10,4 +10,4 @@ license = "MIT"
 edition = "2018"
 
 [dependencies]
-timely = "^0.9"
+timely = "^0.10"

--- a/tdiag/Cargo.toml
+++ b/tdiag/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 edition = "2018"
 
 [dependencies]
-timely = "^0.9"
-differential-dataflow = "^0.9"
+timely = "^0.10"
+differential-dataflow = "^0.10"
 clap = "^2.33"
 tdiag-connect = "^0.1"


### PR DESCRIPTION
This fixes #8 .

Currently, `tdiag` won't build since it relies on the crates.io 0.1 release which still uses 0.9 dependencies. If you'd like me to, I can also bump the crate versions & `connect` dependency from `0.1.1-pre` to e.g. `0.1.2-pre`?