### PR TITLE
Upgrade to 0.11 and support drop events

### DIFF
--- a/connect/Cargo.toml
+++ b/connect/Cargo.toml
@@ -10,4 +10,4 @@ license = "MIT"
 edition = "2018"
 
 [dependencies]
-timely = "^0.10"
+timely = "^0.11"

--- a/tdiag/Cargo.toml
+++ b/tdiag/Cargo.toml
@@ -10,8 +10,8 @@ license = "MIT"
 edition = "2018"
 
 [dependencies]
-timely = "^0.10"
-differential-dataflow = "^0.10"
+timely = "^0.11"
+differential-dataflow = "^0.11"
 clap = "^2.33"
 # tdiag-connect = "^0.2"
 tdiag-connect = { path = "../connect" }

--- a/tdiag/src/commands/arrangements.rs
+++ b/tdiag/src/commands/arrangements.rs
@@ -13,7 +13,7 @@ use TimelyEvent::Operates;
 use differential_dataflow::collection::AsCollection;
 use differential_dataflow::logging::DifferentialEvent;
 use differential_dataflow::operators::{Count, Join};
-use DifferentialEvent::{Batch, Merge, MergeShortfall};
+use DifferentialEvent::{Batch, Merge, MergeShortfall, TraceShare};
 
 use tdiag_connect::receive::ReplayWithShutdown;
 
@@ -103,7 +103,9 @@ pub fn listen(
                     MergeShortfall(x) => {
                         eprintln!("MergeShortfall {:?}", x);
                         None
-                    }
+                    },
+                    DifferentialEvent::Drop(x) => Some(((worker, x.operator), t, -(x.length as isize))),
+                    TraceShare(_x) => None,
                 })
                 .as_collection()
                 .delay(move |t| {


### PR DESCRIPTION
This PR upgrades the Timely and DD dependencies to 0.11, fixing a breaking change to the builder interface, and adds support for batch drop events, as mentioned in #12.

(@frankmcsherry )