### PR TITLE
Fix arrangement profiling's --output-interval 

### DIFF
--- a/tdiag/src/main.rs
+++ b/tdiag/src/main.rs
@@ -70,7 +70,7 @@ You can customize the interface and port for the receiver (this program) with --
                              .value_name("MS")
                              .help("Interval (in ms) at which to print arrangement sizes; defaults to 1000ms")
                              .default_value("1000"))
-                        .help("
+                        .after_help("
 Add the following snippet to your Differential computation:
 
 ```


### PR DESCRIPTION
The documentation was manually overridden (I changed it to append the manual part to the auto-generated part), causing documentation for `--output-interval` to be omitted.
Sub-second intervals were not supported. I fixed this, so now millisecond-granularity windows are supported, instead of just whole seconds.